### PR TITLE
NetworkManager.summarize(_:) 구현

### DIFF
--- a/ThreeLinesSummary.xcodeproj/project.pbxproj
+++ b/ThreeLinesSummary.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		AB2FF4E528BF37600050A03B /* NetworkManagerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FF4E428BF37600050A03B /* NetworkManagerIntegrationTests.swift */; };
 		AB2FF4E728BF3C4D0050A03B /* TranslateRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FF4E628BF3C4D0050A03B /* TranslateRequestBody.swift */; };
 		AB2FF4E928BF54710050A03B /* Translate_Good.json in Resources */ = {isa = PBXBuildFile; fileRef = AB2FF4E828BF54710050A03B /* Translate_Good.json */; };
+		AB2FF4F028BF8EFA0050A03B /* SummaryResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FF4EF28BF8EFA0050A03B /* SummaryResponseBody.swift */; };
 		AB3AE7D228BF080300002CF8 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AE7D128BF080300002CF8 /* NetworkError.swift */; };
 		AB3AE7D428BF0A6000002CF8 /* ErrorResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AE7D328BF0A6000002CF8 /* ErrorResponseBody.swift */; };
 		AB3AE7D628BF0C9400002CF8 /* Translate_Bad_NotDecodable.json in Resources */ = {isa = PBXBuildFile; fileRef = AB3AE7D528BF0C9400002CF8 /* Translate_Bad_NotDecodable.json */; };
@@ -83,6 +84,7 @@
 		AB2FF4E428BF37600050A03B /* NetworkManagerIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManagerIntegrationTests.swift; sourceTree = "<group>"; };
 		AB2FF4E628BF3C4D0050A03B /* TranslateRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateRequestBody.swift; sourceTree = "<group>"; };
 		AB2FF4E828BF54710050A03B /* Translate_Good.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Translate_Good.json; sourceTree = "<group>"; };
+		AB2FF4EF28BF8EFA0050A03B /* SummaryResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryResponseBody.swift; sourceTree = "<group>"; };
 		AB3AE7D128BF080300002CF8 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		AB3AE7D328BF0A6000002CF8 /* ErrorResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorResponseBody.swift; sourceTree = "<group>"; };
 		AB3AE7D528BF0C9400002CF8 /* Translate_Bad_NotDecodable.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Translate_Bad_NotDecodable.json; sourceTree = "<group>"; };
@@ -212,6 +214,7 @@
 				AB3AE7D128BF080300002CF8 /* NetworkError.swift */,
 				AB3AE7D328BF0A6000002CF8 /* ErrorResponseBody.swift */,
 				AB2FF4E628BF3C4D0050A03B /* TranslateRequestBody.swift */,
+				AB2FF4EF28BF8EFA0050A03B /* SummaryResponseBody.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -423,6 +426,7 @@
 				AB2FDA8328BDC96F0008826F /* TranslateView.swift in Sources */,
 				ABB8B80528B8B0D600B7818F /* AppDelegate.swift in Sources */,
 				ABEC710B28BC75F900488104 /* BorderedTextField.swift in Sources */,
+				AB2FF4F028BF8EFA0050A03B /* SummaryResponseBody.swift in Sources */,
 				ABB8B80728B8B0D600B7818F /* SceneDelegate.swift in Sources */,
 				ABEC711828BCA9C900488104 /* UIButton.swift in Sources */,
 				AB2FF4E328BF353F0050A03B /* TranslateAPIAuth.swift in Sources */,

--- a/ThreeLinesSummary.xcodeproj/project.pbxproj
+++ b/ThreeLinesSummary.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		AB2FF4E728BF3C4D0050A03B /* TranslateRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FF4E628BF3C4D0050A03B /* TranslateRequestBody.swift */; };
 		AB2FF4E928BF54710050A03B /* Translate_Good.json in Resources */ = {isa = PBXBuildFile; fileRef = AB2FF4E828BF54710050A03B /* Translate_Good.json */; };
 		AB2FF4F028BF8EFA0050A03B /* SummaryResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FF4EF28BF8EFA0050A03B /* SummaryResponseBody.swift */; };
+		AB2FF4F228BF9A8D0050A03B /* SummaryRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FF4F128BF9A8D0050A03B /* SummaryRequestBody.swift */; };
+		AB2FF4F428BF9C250050A03B /* SummaryAPIAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FF4F328BF9C250050A03B /* SummaryAPIAuth.swift */; };
 		AB3AE7D228BF080300002CF8 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AE7D128BF080300002CF8 /* NetworkError.swift */; };
 		AB3AE7D428BF0A6000002CF8 /* ErrorResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AE7D328BF0A6000002CF8 /* ErrorResponseBody.swift */; };
 		AB3AE7D628BF0C9400002CF8 /* Translate_Bad_NotDecodable.json in Resources */ = {isa = PBXBuildFile; fileRef = AB3AE7D528BF0C9400002CF8 /* Translate_Bad_NotDecodable.json */; };
@@ -85,6 +87,8 @@
 		AB2FF4E628BF3C4D0050A03B /* TranslateRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateRequestBody.swift; sourceTree = "<group>"; };
 		AB2FF4E828BF54710050A03B /* Translate_Good.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Translate_Good.json; sourceTree = "<group>"; };
 		AB2FF4EF28BF8EFA0050A03B /* SummaryResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryResponseBody.swift; sourceTree = "<group>"; };
+		AB2FF4F128BF9A8D0050A03B /* SummaryRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryRequestBody.swift; sourceTree = "<group>"; };
+		AB2FF4F328BF9C250050A03B /* SummaryAPIAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryAPIAuth.swift; sourceTree = "<group>"; };
 		AB3AE7D128BF080300002CF8 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		AB3AE7D328BF0A6000002CF8 /* ErrorResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorResponseBody.swift; sourceTree = "<group>"; };
 		AB3AE7D528BF0C9400002CF8 /* Translate_Bad_NotDecodable.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Translate_Bad_NotDecodable.json; sourceTree = "<group>"; };
@@ -203,6 +207,7 @@
 			isa = PBXGroup;
 			children = (
 				AB2FF4E228BF353F0050A03B /* TranslateAPIAuth.swift */,
+				AB2FF4F328BF9C250050A03B /* SummaryAPIAuth.swift */,
 			);
 			path = Secrets;
 			sourceTree = "<group>";
@@ -215,6 +220,7 @@
 				AB3AE7D328BF0A6000002CF8 /* ErrorResponseBody.swift */,
 				AB2FF4E628BF3C4D0050A03B /* TranslateRequestBody.swift */,
 				AB2FF4EF28BF8EFA0050A03B /* SummaryResponseBody.swift */,
+				AB2FF4F128BF9A8D0050A03B /* SummaryRequestBody.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -414,6 +420,7 @@
 			files = (
 				AB3AE7D228BF080300002CF8 /* NetworkError.swift in Sources */,
 				AB3AE7D428BF0A6000002CF8 /* ErrorResponseBody.swift in Sources */,
+				AB2FF4F228BF9A8D0050A03B /* SummaryRequestBody.swift in Sources */,
 				AB2FDA8E28BE308B0008826F /* URLSessionProtocol.swift in Sources */,
 				ABEC711428BC8A2000488104 /* PhaseTemplateView.swift in Sources */,
 				ABB8B80928B8B0D600B7818F /* ViewController.swift in Sources */,
@@ -422,6 +429,7 @@
 				ABEC710E28BC7F0300488104 /* UIImageView.swift in Sources */,
 				ABEC711028BC81D400488104 /* CustomButton.swift in Sources */,
 				AB2FDA8928BDD9E20008826F /* LoadingView.swift in Sources */,
+				AB2FF4F428BF9C250050A03B /* SummaryAPIAuth.swift in Sources */,
 				AB2FF4E728BF3C4D0050A03B /* TranslateRequestBody.swift in Sources */,
 				AB2FDA8328BDC96F0008826F /* TranslateView.swift in Sources */,
 				ABB8B80528B8B0D600B7818F /* AppDelegate.swift in Sources */,

--- a/ThreeLinesSummary/Models/NetworkError.swift
+++ b/ThreeLinesSummary/Models/NetworkError.swift
@@ -12,4 +12,5 @@ enum NetworkError: Error {
     case unknown
     case longText
     case emptyText
+    case encoding
 }

--- a/ThreeLinesSummary/Models/NetworkError.swift
+++ b/ThreeLinesSummary/Models/NetworkError.swift
@@ -13,4 +13,5 @@ enum NetworkError: Error {
     case longText
     case emptyText
     case encoding
+    case invalidText
 }

--- a/ThreeLinesSummary/Models/SummaryRequestBody.swift
+++ b/ThreeLinesSummary/Models/SummaryRequestBody.swift
@@ -1,0 +1,28 @@
+//
+//  SummaryRequestBody.swift
+//  ThreeLinesSummary
+//
+//  Created by 김남건 on 2022/08/31.
+//
+
+import Foundation
+
+struct SummaryRequestBody: Encodable {
+    let document: Document
+    let option = Option()
+    
+    init(content: String) {
+        self.document = Document(content: content)
+    }
+    
+    struct Document: Encodable {
+        let content: String
+    }
+    
+    struct Option: Encodable {
+        let language = "ko"
+        let model = "general"
+        let tone = 0
+        let summaryCount = 3
+    }
+}

--- a/ThreeLinesSummary/Models/SummaryResponseBody.swift
+++ b/ThreeLinesSummary/Models/SummaryResponseBody.swift
@@ -1,0 +1,16 @@
+//
+//  SummaryResponseBody.swift
+//  ThreeLinesSummary
+//
+//  Created by 김남건 on 2022/08/31.
+//
+
+import Foundation
+
+struct SummaryResponseBody: Decodable {
+    let document: Document
+    
+    struct Document: Decodable {
+        let content: String
+    }
+}

--- a/ThreeLinesSummary/Models/SummaryResponseBody.swift
+++ b/ThreeLinesSummary/Models/SummaryResponseBody.swift
@@ -8,9 +8,5 @@
 import Foundation
 
 struct SummaryResponseBody: Decodable {
-    let document: Document
-    
-    struct Document: Decodable {
-        let content: String
-    }
+    let summary: String
 }

--- a/ThreeLinesSummary/Network/NetworkManager.swift
+++ b/ThreeLinesSummary/Network/NetworkManager.swift
@@ -59,4 +59,16 @@ struct NetworkManager {
         
         return try? JSONEncoder().encode(body)
     }
+    
+    func summarize(_ text: String) async throws -> String {
+        let urlRequest = URLRequest(url: URL(string: "www.naver.com")!)
+        
+        let (data, response) = try await urlSession.data(for: urlRequest)
+        
+        if let responseBody = try? JSONDecoder().decode(SummaryResponseBody.self, from: data) {
+            return responseBody.document.content
+        }
+        
+        throw NetworkError.unknown
+    }
 }

--- a/ThreeLinesSummary/Network/NetworkManager.swift
+++ b/ThreeLinesSummary/Network/NetworkManager.swift
@@ -77,6 +77,15 @@ struct NetworkManager {
             throw NetworkError.serverError
         }
         
-        throw NetworkError.unknown
+        guard let errorResponseBody = try? JSONDecoder().decode(ErrorResponseBody.self, from: data) else {
+            throw NetworkError.unknown
+        }
+        
+        switch errorResponseBody.error.errorCode {
+        case "E001":
+            throw NetworkError.emptyText
+        default:
+            throw NetworkError.unknown
+        }
     }
 }

--- a/ThreeLinesSummary/Network/NetworkManager.swift
+++ b/ThreeLinesSummary/Network/NetworkManager.swift
@@ -20,7 +20,7 @@ struct NetworkManager {
             throw NetworkError.unknown
         }
         
-        guard let body = getBody(with: text) else {
+        guard let body = getTranslateRequestBody(with: text) else {
             throw NetworkError.unknown
         }
         
@@ -54,19 +54,27 @@ struct NetworkManager {
         }
     }
     
-    private func getBody(with text: String) -> Data? {
+    private func getTranslateRequestBody(with text: String) -> Data? {
         let body = TranslateRequestBody(text: text)
         
         return try? JSONEncoder().encode(body)
     }
     
     func summarize(_ text: String) async throws -> String {
-        let urlRequest = URLRequest(url: URL(string: "www.naver.com")!)
+        guard var urlRequest = SummaryAPIAuth.urlRequest else {
+            throw NetworkError.unknown
+        }
+        
+        guard let body = getSummaryRequestBody(with: text) else {
+            throw NetworkError.unknown
+        }
+        
+        urlRequest.httpBody = body
         
         let (data, response) = try await urlSession.data(for: urlRequest)
         
         if let responseBody = try? JSONDecoder().decode(SummaryResponseBody.self, from: data) {
-            return responseBody.document.content
+            return responseBody.summary
         }
         
         guard let response = response as? HTTPURLResponse else {
@@ -93,5 +101,11 @@ struct NetworkManager {
         default:
             throw NetworkError.unknown
         }
+    }
+    
+    private func getSummaryRequestBody(with text: String) -> Data? {
+        let body = SummaryRequestBody(content: text)
+        
+        return try? JSONEncoder().encode(body)
     }
 }

--- a/ThreeLinesSummary/Network/NetworkManager.swift
+++ b/ThreeLinesSummary/Network/NetworkManager.swift
@@ -86,6 +86,8 @@ struct NetworkManager {
             throw NetworkError.emptyText
         case "E002":
             throw NetworkError.encoding
+        case "E003":
+            throw NetworkError.longText
         default:
             throw NetworkError.unknown
         }

--- a/ThreeLinesSummary/Network/NetworkManager.swift
+++ b/ThreeLinesSummary/Network/NetworkManager.swift
@@ -69,6 +69,14 @@ struct NetworkManager {
             return responseBody.document.content
         }
         
+        guard let response = response as? HTTPURLResponse else {
+            throw NetworkError.unknown
+        }
+        
+        if response.statusCode >= 500 {
+            throw NetworkError.serverError
+        }
+        
         throw NetworkError.unknown
     }
 }

--- a/ThreeLinesSummary/Network/NetworkManager.swift
+++ b/ThreeLinesSummary/Network/NetworkManager.swift
@@ -84,6 +84,8 @@ struct NetworkManager {
         switch errorResponseBody.error.errorCode {
         case "E001":
             throw NetworkError.emptyText
+        case "E002":
+            throw NetworkError.encoding
         default:
             throw NetworkError.unknown
         }

--- a/ThreeLinesSummary/Network/NetworkManager.swift
+++ b/ThreeLinesSummary/Network/NetworkManager.swift
@@ -88,6 +88,8 @@ struct NetworkManager {
             throw NetworkError.encoding
         case "E003":
             throw NetworkError.longText
+        case "E100":
+            throw NetworkError.invalidText
         default:
             throw NetworkError.unknown
         }

--- a/ThreeLinesSummaryTests/Network/NetworkManagerIntegrationTests.swift
+++ b/ThreeLinesSummaryTests/Network/NetworkManagerIntegrationTests.swift
@@ -27,13 +27,31 @@ class NetworkManagerIntegrationTests: XCTestCase {
     func testTranslate() {
         Task {
             do {
-                let text = try await sut.translate("I believe I can fly.")
-                XCTAssertEqual(text, "난 내가 날 수 있다고 믿어요.")
+                let result = try await sut.translate("I believe I can fly.")
+                XCTAssertEqual(result, "난 내가 날 수 있다고 믿어요.")
                 expectation.fulfill()
             } catch {
                 
             }
             
+        }
+        
+        wait(for: [expectation], timeout: 3)
+    }
+    
+    func testSummarize() {
+        let text = "간편송금 이용금액이 하루 평균 2000억원을 넘어섰다. 한국은행이 17일 발표한 '2019년 상반기중 전자지급서비스 이용 현황'에 따르면 올해 상반기 간편송금서비스 이용금액(일평균)은 지난해 하반기 대비 60.7% 증가한 2005억원으로 집계됐다. 같은 기간 이용건수(일평균)는 34.8% 늘어난 218만건이었다. 간편 송금 시장에는 선불전자지급서비스를 제공하는 전자금융업자와 금융기관 등이 참여하고 있다. 이용금액은 전자금융업자가 하루평균 1879억원, 금융기관이 126억원이었다. 한은은 카카오페이, 토스 등 간편송금 서비스를 제공하는 업체 간 경쟁이 심화되면서 이용규모가 크게 확대됐다고 분석했다. 국회 정무위원회 소속 바른미래당 유의동 의원에 따르면 카카오페이, 토스 등 선불전자지급서비스 제공업체는 지난해 마케팅 비용으로 1000억원 이상을 지출했다. 마케팅 비용 지출규모는 카카오페이가 491억원, 비바리퍼블리카(토스)가 134억원 등 순으로 많았다."
+        
+        let expectedResult = "한국은행이 17일 발표한 '2019년 상반기중 전자지급서비스 이용 현황'에 따르면 올해 상반기 간편송금서비스 이용금액(일평균)은 지난해 하반기 대비 60.7% 증가한 2005억원으로 집계됐다.\n한은은 카카오페이, 토스 등 간편송금 서비스를 제공하는 업체 간 경쟁이 심화되면서 이용규모가 크게 확대됐다고 분석했다.\n국회 정무위원회 소속 바른미래당 유의동 의원에 따르면 카카오페이, 토스 등 선불전자지급서비스 제공업체는 지난해 마케팅 비용으로 1000억원 이상을 지출했다."
+        
+        Task {
+            do {
+                let result = try await sut.summarize(text)
+                XCTAssertEqual(result, expectedResult)
+                expectation.fulfill()
+            } catch {
+                XCTFail("error!!!")
+            }
         }
         
         wait(for: [expectation], timeout: 3)

--- a/ThreeLinesSummaryTests/Network/NetworkManagerIntegrationTests.swift
+++ b/ThreeLinesSummaryTests/Network/NetworkManagerIntegrationTests.swift
@@ -56,4 +56,18 @@ class NetworkManagerIntegrationTests: XCTestCase {
         
         wait(for: [expectation], timeout: 3)
     }
+    
+    func testSummarize_whenTextIsEmpty_throwsEmptyText() {
+        Task {
+            do {
+                let _ = try await sut.summarize("")
+            } catch {
+                XCTAssertTrue(error is NetworkError)
+                XCTAssertEqual(error as? NetworkError, NetworkError.emptyText)
+                expectation.fulfill()
+            }
+        }
+        
+        wait(for: [expectation], timeout: 3)
+    }
 }

--- a/ThreeLinesSummaryTests/Network/NetworkManagerUnitTests.swift
+++ b/ThreeLinesSummaryTests/Network/NetworkManagerUnitTests.swift
@@ -84,12 +84,14 @@ class NetworkManagerUnitTests: XCTestCase {
         let expectedText = responseBody.message.result.translatedText
         
         Task {
-            // when
-            let text = try! await sut.translate("dummy Text")
-            
-            // then
-            XCTAssertEqual(text, expectedText)
-            expectation.fulfill()
+            do {
+                // when
+                let text = try await sut.translate("dummy Text")
+                
+                // then
+                XCTAssertEqual(text, expectedText)
+                expectation.fulfill()
+            } catch {}
         }
         
         wait(for: [expectation], timeout: 1)
@@ -144,5 +146,11 @@ class NetworkManagerUnitTests: XCTestCase {
         givenSutAndExpectation(statusCode: 500, fileName: "Summary_Bad_500")
         
         whenSummarizeThrowsNetworkError(expectedError: .serverError)
+    }
+    
+    func testSummarize_whenErrorCodeIsE001_throwsEmptyText() {
+        givenSutAndExpectation(statusCode: 400, fileName: "Summary_Bad_400_E001")
+        
+        whenSummarizeThrowsNetworkError(expectedError: .emptyText)
     }
 }

--- a/ThreeLinesSummaryTests/Network/NetworkManagerUnitTests.swift
+++ b/ThreeLinesSummaryTests/Network/NetworkManagerUnitTests.swift
@@ -126,7 +126,7 @@ class NetworkManagerUnitTests: XCTestCase {
         
         let data = try! Data.fromJSON(fileName: "Summary_Good")
         let responseBody = try! JSONDecoder().decode(SummaryResponseBody.self, from: data)
-        let expectedText = responseBody.document.content
+        let expectedText = responseBody.summary
         
         Task {
             do {

--- a/ThreeLinesSummaryTests/Network/NetworkManagerUnitTests.swift
+++ b/ThreeLinesSummaryTests/Network/NetworkManagerUnitTests.swift
@@ -102,4 +102,25 @@ class NetworkManagerUnitTests: XCTestCase {
         
         whenThrowsNetworkError(expectedError: .longText)
     }
+    
+    func testSummarize_whenResponseIsGood_returnsText() {
+        givenSutAndExpectation(statusCode: 200, fileName: "Summary_Good")
+        
+        let data = try! Data.fromJSON(fileName: "Summary_Good")
+        let responseBody = try! JSONDecoder().decode(SummaryResponseBody.self, from: data)
+        let expectedText = responseBody.document.content
+        
+        Task {
+            do {
+                // when
+                let text = try await sut.summarize("dummy Text")
+                
+                // then
+                XCTAssertEqual(text, expectedText)
+                expectation.fulfill()
+            } catch {}
+        }
+        
+        wait(for: [expectation], timeout: 1)
+    }
 }

--- a/ThreeLinesSummaryTests/Network/NetworkManagerUnitTests.swift
+++ b/ThreeLinesSummaryTests/Network/NetworkManagerUnitTests.swift
@@ -27,11 +27,27 @@ class NetworkManagerUnitTests: XCTestCase {
         expectation = expectation(description: "Task should be executed during test.")
     }
     
-    func whenThrowsNetworkError(expectedError: NetworkError) {
+    func whenTranslateThrowsNetworkError(expectedError: NetworkError) {
         Task {
             do {
                 // when
                 let _ = try await sut.translate("dummy text")
+            } catch {
+                // then
+                XCTAssertTrue(error is NetworkError)
+                XCTAssertEqual(error as! NetworkError, expectedError)
+                expectation.fulfill()
+            }
+        }
+        
+        wait(for: [expectation], timeout: 1)
+    }
+    
+    func whenSummarizeThrowsNetworkError(expectedError: NetworkError) {
+        Task {
+            do {
+                // when
+                let _ = try await sut.summarize("dummy text")
             } catch {
                 // then
                 XCTAssertTrue(error is NetworkError)
@@ -82,25 +98,25 @@ class NetworkManagerUnitTests: XCTestCase {
     func testTranslate_WhenStatusCodeIsAtLeast500_throwsServerError() {
         givenSutAndExpectation(statusCode: 500, fileName: "Translate_Bad_500_900")
         
-        whenThrowsNetworkError(expectedError: .serverError)
+        whenTranslateThrowsNetworkError(expectedError: .serverError)
     }
     
     func testTranslate_WhenNotDecodableResponseBody_throwsUnknown() {
         givenSutAndExpectation(statusCode: 400, fileName: "Translate_Bad_NotDecodable")
         
-        whenThrowsNetworkError(expectedError: .unknown)
+        whenTranslateThrowsNetworkError(expectedError: .unknown)
     }
     
     func testTranslate_WhenErrorCodeIs430_throwsLongText() {
         givenSutAndExpectation(statusCode: 413, fileName: "Translate_Bad_413_430")
         
-        whenThrowsNetworkError(expectedError: .longText)
+        whenTranslateThrowsNetworkError(expectedError: .longText)
     }
     
     func testTranslate_WhenErrorCodeIsN2MT08_throwsLongText() {
         givenSutAndExpectation(statusCode: 400, fileName: "Translate_Bad_400_N2MT08")
         
-        whenThrowsNetworkError(expectedError: .longText)
+        whenTranslateThrowsNetworkError(expectedError: .longText)
     }
     
     func testSummarize_whenResponseIsGood_returnsText() {
@@ -122,5 +138,11 @@ class NetworkManagerUnitTests: XCTestCase {
         }
         
         wait(for: [expectation], timeout: 1)
+    }
+    
+    func testSummarize_whenStatusCodeIsAtLeast500_throwsServerError() {
+        givenSutAndExpectation(statusCode: 500, fileName: "Summary_Bad_500")
+        
+        whenSummarizeThrowsNetworkError(expectedError: .serverError)
     }
 }

--- a/ThreeLinesSummaryTests/Network/NetworkManagerUnitTests.swift
+++ b/ThreeLinesSummaryTests/Network/NetworkManagerUnitTests.swift
@@ -153,4 +153,10 @@ class NetworkManagerUnitTests: XCTestCase {
         
         whenSummarizeThrowsNetworkError(expectedError: .emptyText)
     }
+    
+    func testSummarize_whenErrorCodeIsE002_throwsEncoding() {
+        givenSutAndExpectation(statusCode: 400, fileName: "Summary_Bad_400_E002")
+        
+        whenSummarizeThrowsNetworkError(expectedError: .encoding)
+    }
 }

--- a/ThreeLinesSummaryTests/Network/NetworkManagerUnitTests.swift
+++ b/ThreeLinesSummaryTests/Network/NetworkManagerUnitTests.swift
@@ -165,4 +165,10 @@ class NetworkManagerUnitTests: XCTestCase {
         
         whenSummarizeThrowsNetworkError(expectedError: .longText)
     }
+    
+    func testSummarize_whenErrorCodeIsE100_throwsInvalidText() {
+        givenSutAndExpectation(statusCode: 400, fileName: "Summary_Bad_400_E100")
+        
+        whenSummarizeThrowsNetworkError(expectedError: .invalidText)
+    }
 }

--- a/ThreeLinesSummaryTests/Network/NetworkManagerUnitTests.swift
+++ b/ThreeLinesSummaryTests/Network/NetworkManagerUnitTests.swift
@@ -159,4 +159,10 @@ class NetworkManagerUnitTests: XCTestCase {
         
         whenSummarizeThrowsNetworkError(expectedError: .encoding)
     }
+    
+    func testSummarize_whenErrorCodeIsE003_throwsLongText() {
+        givenSutAndExpectation(statusCode: 400, fileName: "Summary_Bad_400_E003")
+        
+        whenSummarizeThrowsNetworkError(expectedError: .longText)
+    }
 }

--- a/ThreeLinesSummaryTests/Network/ResponseData/Summary/Summary_Good.json
+++ b/ThreeLinesSummaryTests/Network/ResponseData/Summary/Summary_Good.json
@@ -1,12 +1,3 @@
 {
-    "document": {
-        "title": "'하루 2000억' 판 커지는 간편송금 시장",
-        "content": "간편송금 이용금액이 하루 평균 2000억원을 넘어섰다."
-    },
-    "option": {
-        "language": "ko",
-        "model": "news",
-        "tone": 2,
-        "summaryCount": 3
-    }
+    "summary": "tea"
 }


### PR DESCRIPTION
## 설명
* `SummaryAPIAuth` 추가
    - 요약 API 호출에 필요한 값 저장
    - gitignore에 포함되어 gitHub에는 반영 X
* `SummaryRequestBody` 추가
    - 요약 API 호출에 필요한 body 구조
* `SummaryResponseBody` 추가
    - 요약 API 호출 결과를 decoding하기 위한 타입
* `NetworkError`에 case 추가
    - encoding, invalidText
* `summarize(_:)` 메서드 및 unit/integration test 추가

## 파일 경로
* ThreeLinesSummary/Secrets/SummaryAPIAuth.swift
* ThreeLinesSummary/Models/*
    - NetworkError.swift, SummaryRequestBody.swift, SummaryResponseBody.swift
* ThreeLinesSummaryTests/*
    - NetworkManagerUnitTests.swift, NetworkManagerIntegrationTests.swift
