### PR TITLE
View 연결 및 API 연동

### DIFF
--- a/ThreeLinesSummary.xcodeproj/project.pbxproj
+++ b/ThreeLinesSummary.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AB21AED528C0736200247199 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB21AED428C0736200247199 /* ViewModel.swift */; };
 		AB2FDA8328BDC96F0008826F /* TranslateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FDA8228BDC96F0008826F /* TranslateView.swift */; };
 		AB2FDA8528BDD5FA0008826F /* SummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FDA8428BDD5FA0008826F /* SummaryView.swift */; };
 		AB2FDA8928BDD9E20008826F /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FDA8828BDD9E20008826F /* LoadingView.swift */; };
@@ -63,6 +64,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		AB21AED428C0736200247199 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		AB2FDA8228BDC96F0008826F /* TranslateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateView.swift; sourceTree = "<group>"; };
 		AB2FDA8428BDD5FA0008826F /* SummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryView.swift; sourceTree = "<group>"; };
 		AB2FDA8828BDD9E20008826F /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
@@ -129,6 +131,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		AB21AED328C0735300247199 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				AB21AED428C0736200247199 /* ViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
 		AB2FDA8C28BE307E0008826F /* Network */ = {
 			isa = PBXGroup;
 			children = (
@@ -246,6 +256,7 @@
 		ABB8B80328B8B0D600B7818F /* ThreeLinesSummary */ = {
 			isa = PBXGroup;
 			children = (
+				AB21AED328C0735300247199 /* ViewModels */,
 				AB2FF4E128BF352E0050A03B /* Secrets */,
 				AB3EF2B628BE6521006B5327 /* Models */,
 				AB2FDA8C28BE307E0008826F /* Network */,
@@ -440,6 +451,7 @@
 				AB2FF4E328BF353F0050A03B /* TranslateAPIAuth.swift in Sources */,
 				AB2FDA8B28BDE21E0008826F /* ErrorView.swift in Sources */,
 				AB2FDA8528BDD5FA0008826F /* SummaryView.swift in Sources */,
+				AB21AED528C0736200247199 /* ViewModel.swift in Sources */,
 				AB3EF2B828BE66B1006B5327 /* TranslateResponseBody.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ThreeLinesSummary/Models/NetworkError.swift
+++ b/ThreeLinesSummary/Models/NetworkError.swift
@@ -14,4 +14,21 @@ enum NetworkError: Error {
     case emptyText
     case encoding
     case invalidText
+    
+    var message: String {
+        switch self {
+        case .serverError:
+            return "서버에서 에러가 발생했습니다. 다시 시도해보세요."
+        case .unknown:
+            return "알 수 없는 에러가 발생했습니다."
+        case .longText:
+            return "텍스트가 너무 깁니다."
+        case .emptyText:
+            return "텍스트가 비어 있습니다."
+        case .encoding:
+            return "인코딩에 문제가 있습니다."
+        case .invalidText:
+            return "유효하지 않은 텍스트입니다."
+        }
+    }
 }

--- a/ThreeLinesSummary/ViewController.swift
+++ b/ThreeLinesSummary/ViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 
 class ViewController: UIViewController {
     let pasteView = PasteView()
@@ -14,9 +15,67 @@ class ViewController: UIViewController {
     let loadingView = LoadingView()
     let errorView = ErrorView()
     
+    private var viewModel = ViewModel()
+    private var subscriptions = Set<AnyCancellable>()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+        
+        viewModel.$currentPhase
+            .receive(on: DispatchQueue.main)
+            .map { [unowned self] phase -> UIView in
+                switch phase {
+                case .pasted:
+                    return pasteView
+                case .finishedTranslate:
+                    return translateView
+                case .finishedSummarize:
+                    return summaryView
+                case .translating, .summarizing:
+                    return loadingView
+                case .failedTranslate, .failedSummarize:
+                    return errorView
+                }
+            }
+            .sink { [unowned self] view in
+                self.view = view
+            }
+            .store(in: &subscriptions)
+        
+        viewModel.$pastedText
+            .receive(on: DispatchQueue.main)
+            .sink { [unowned self] text in
+                pasteView.textField.text = text
+            }
+            .store(in: &subscriptions)
+        
+        viewModel.$translateResult
+            .receive(on: DispatchQueue.main)
+            .sink { [unowned self] result in
+                translateView.textField.text = result
+            }
+            .store(in: &subscriptions)
+        
+        viewModel.$summaryResult
+            .receive(on: DispatchQueue.main)
+            .sink { [unowned self] result in
+                summaryView.textField.text = result
+            }
+            .store(in: &subscriptions)
+        
+        viewModel.$loadingMessage
+            .receive(on: DispatchQueue.main)
+            .sink { [unowned self] message in
+                loadingView.message = message
+            }
+            .store(in: &subscriptions)
+        
+        viewModel.$errorMessage
+            .receive(on: DispatchQueue.main)
+            .sink { [unowned self] message in
+                errorView.message = message
+            }
+            .store(in: &subscriptions)
     }
 
 

--- a/ThreeLinesSummary/ViewController.swift
+++ b/ThreeLinesSummary/ViewController.swift
@@ -77,10 +77,16 @@ class ViewController: UIViewController {
             .store(in: &subscriptions)
         
         pasteView.translateButton.addTarget(self, action: #selector(translateButtonClicked), for: .touchUpInside)
+        translateView.goBackButton.addTarget(self, action: #selector(goBack), for: .touchUpInside)
+        errorView.goBackButton.addTarget(self, action: #selector(goBack), for: .touchUpInside)
     }
 
     @objc private func translateButtonClicked() {
         viewModel.translate(pasteView.textField.text)
+    }
+    
+    @objc private func goBack() {
+        viewModel.goBack()
     }
 }
 

--- a/ThreeLinesSummary/ViewController.swift
+++ b/ThreeLinesSummary/ViewController.swift
@@ -81,6 +81,9 @@ class ViewController: UIViewController {
         
         translateView.goBackButton.addTarget(self, action: #selector(goBack), for: .touchUpInside)
         errorView.goBackButton.addTarget(self, action: #selector(goBack), for: .touchUpInside)
+        
+        errorView.goToStartButton.addTarget(self, action: #selector(goToStart), for: .touchUpInside)
+        summaryView.goToStartButton.addTarget(self, action: #selector(goToStart), for: .touchUpInside)
     }
 
     @objc private func translateButtonClicked() {
@@ -93,6 +96,10 @@ class ViewController: UIViewController {
     
     @objc private func summarize() {
         viewModel.summarize(translateView.textField.text)
+    }
+    
+    @objc private func goToStart() {
+        viewModel.goToStart()
     }
 }
 

--- a/ThreeLinesSummary/ViewController.swift
+++ b/ThreeLinesSummary/ViewController.swift
@@ -23,22 +23,21 @@ class ViewController: UIViewController {
         
         viewModel.$currentPhase
             .receive(on: DispatchQueue.main)
-            .map { [unowned self] phase -> UIView in
+            .sink { [unowned self] phase in
                 switch phase {
                 case .pasted:
-                    return pasteView
+                    self.view = pasteView
                 case .finishedTranslate:
-                    return translateView
+                    self.view = translateView
                 case .finishedSummarize:
-                    return summaryView
+                    self.view = summaryView
                 case .translating, .summarizing:
-                    return loadingView
+                    self.view = loadingView
                 case .failedTranslate, .failedSummarize:
-                    return errorView
+                    self.view = errorView
                 }
-            }
-            .sink { [unowned self] view in
-                self.view = view
+                
+                self.title = phase.navigationTitle
             }
             .store(in: &subscriptions)
         

--- a/ThreeLinesSummary/ViewController.swift
+++ b/ThreeLinesSummary/ViewController.swift
@@ -77,6 +77,8 @@ class ViewController: UIViewController {
             .store(in: &subscriptions)
         
         pasteView.translateButton.addTarget(self, action: #selector(translateButtonClicked), for: .touchUpInside)
+        translateView.summarizeButton.addTarget(self, action: #selector(summarize), for: .touchUpInside)
+        
         translateView.goBackButton.addTarget(self, action: #selector(goBack), for: .touchUpInside)
         errorView.goBackButton.addTarget(self, action: #selector(goBack), for: .touchUpInside)
     }
@@ -87,6 +89,10 @@ class ViewController: UIViewController {
     
     @objc private func goBack() {
         viewModel.goBack()
+    }
+    
+    @objc private func summarize() {
+        viewModel.summarize(translateView.textField.text)
     }
 }
 

--- a/ThreeLinesSummary/ViewController.swift
+++ b/ThreeLinesSummary/ViewController.swift
@@ -76,8 +76,12 @@ class ViewController: UIViewController {
                 errorView.message = message
             }
             .store(in: &subscriptions)
+        
+        pasteView.translateButton.addTarget(self, action: #selector(translateButtonClicked), for: .touchUpInside)
     }
 
-
+    @objc private func translateButtonClicked() {
+        viewModel.translate(pasteView.textField.text)
+    }
 }
 

--- a/ThreeLinesSummary/ViewController.swift
+++ b/ThreeLinesSummary/ViewController.swift
@@ -8,7 +8,12 @@
 import UIKit
 
 class ViewController: UIViewController {
-
+    let pasteView = PasteView()
+    let translateView = TranslateView()
+    let summaryView = SummaryView()
+    let loadingView = LoadingView()
+    let errorView = ErrorView()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.

--- a/ThreeLinesSummary/ViewModels/ViewModel.swift
+++ b/ThreeLinesSummary/ViewModels/ViewModel.swift
@@ -61,4 +61,15 @@ class ViewModel: ObservableObject {
             }
         }
     }
+    
+    func goBack() {
+        switch currentPhase {
+        case .failedTranslate, .finishedTranslate:
+            currentPhase = .pasted
+        case .failedSummarize, .finishedSummarize:
+            currentPhase = .finishedTranslate
+        default:
+            break
+        }
+    }
 }

--- a/ThreeLinesSummary/ViewModels/ViewModel.swift
+++ b/ThreeLinesSummary/ViewModels/ViewModel.swift
@@ -43,4 +43,22 @@ class ViewModel: ObservableObject {
     @Published private(set) var summaryResult = ""
     @Published private(set) var loadingMessage = ""
     @Published private(set) var errorMessage = ""
+    private var networkManager = NetworkManager(urlSession: URLSession.shared)
+    
+    func translate(_ text: String) {
+        currentPhase = .translating
+        loadingMessage = "번역 중..."
+        
+        Task {
+            do {
+                let result = try await networkManager.translate(text)
+                currentPhase = .finishedTranslate
+                translateResult = result
+            } catch {
+                self.currentPhase = .failedTranslate
+                let errorMessage = ((error as? NetworkError) ?? .unknown).message
+                self.errorMessage = errorMessage
+            }
+        }
+    }
 }

--- a/ThreeLinesSummary/ViewModels/ViewModel.swift
+++ b/ThreeLinesSummary/ViewModels/ViewModel.swift
@@ -62,6 +62,23 @@ class ViewModel: ObservableObject {
         }
     }
     
+    func summarize(_ text: String) {
+        currentPhase = .summarizing
+        loadingMessage = "요약 중..."
+        
+        Task {
+            do {
+                let result = try await networkManager.summarize(text)
+                currentPhase = .finishedSummarize
+                summaryResult = result
+            } catch {
+                self.currentPhase = .failedSummarize
+                let errorMessage = ((error as? NetworkError) ?? .unknown).message
+                self.errorMessage = errorMessage
+            }
+        }
+    }
+    
     func goBack() {
         switch currentPhase {
         case .failedTranslate, .finishedTranslate:

--- a/ThreeLinesSummary/ViewModels/ViewModel.swift
+++ b/ThreeLinesSummary/ViewModels/ViewModel.swift
@@ -38,6 +38,9 @@ enum Phase {
 
 class ViewModel: ObservableObject {
     @Published private(set) var currentPhase: Phase = .pasted
+    @Published private(set) var pastedText = ""
+    @Published private(set) var translateResult = ""
+    @Published private(set) var summaryResult = ""
     @Published private(set) var loadingMessage = ""
     @Published private(set) var errorMessage = ""
 }

--- a/ThreeLinesSummary/ViewModels/ViewModel.swift
+++ b/ThreeLinesSummary/ViewModels/ViewModel.swift
@@ -89,4 +89,8 @@ class ViewModel: ObservableObject {
             break
         }
     }
+    
+    func goToStart() {
+        currentPhase = .pasted
+    }
 }

--- a/ThreeLinesSummary/ViewModels/ViewModel.swift
+++ b/ThreeLinesSummary/ViewModels/ViewModel.swift
@@ -1,0 +1,43 @@
+//
+//  ViewModel.swift
+//  ThreeLinesSummary
+//
+//  Created by 김남건 on 2022/09/01.
+//
+
+import Foundation
+
+enum Phase {
+    case pasted
+    case translating
+    case finishedTranslate
+    case failedTranslate
+    case summarizing
+    case finishedSummarize
+    case failedSummarize
+    
+    var navigationTitle: String {
+        switch self {
+        case .pasted:
+            return "영어 텍스트 복사, 붙여넣기"
+        case .translating:
+            return "번역 중"
+        case .finishedTranslate:
+            return "번역 완료"
+        case .failedTranslate:
+            return "번역 실패"
+        case .summarizing:
+            return "요약 중"
+        case .finishedSummarize:
+            return "요약 완료"
+        case .failedSummarize:
+            return "요약 실패"
+        }
+    }
+}
+
+class ViewModel: ObservableObject {
+    @Published private(set) var currentPhase: Phase = .pasted
+    @Published private(set) var loadingMessage = ""
+    @Published private(set) var errorMessage = ""
+}

--- a/ThreeLinesSummary/Views/ErrorView.swift
+++ b/ThreeLinesSummary/Views/ErrorView.swift
@@ -16,8 +16,8 @@ class ErrorView: UIView {
         return label
     }()
     
-    private let goBackButton = UIButton.getSystemButton(title: "이전 단계로", configuration: .filled())
-    private let goToStartButton = UIButton.getSystemButton(title: "처음 단계로", configuration: .tinted())
+    let goBackButton = UIButton.getSystemButton(title: "이전 단계로", configuration: .filled())
+    let goToStartButton = UIButton.getSystemButton(title: "처음 단계로", configuration: .tinted())
     
     var message: String {
         get {

--- a/ThreeLinesSummary/Views/Helpers/BorderedTextField.swift
+++ b/ThreeLinesSummary/Views/Helpers/BorderedTextField.swift
@@ -20,6 +20,16 @@ class BorderedTextField: UIView {
     private var textSubject = CurrentValueSubject<String, Never>("")
     lazy var textPublisher = textSubject.eraseToAnyPublisher()
     
+    var text: String {
+        get {
+            textField.text
+        }
+        
+        set {
+            textField.text = newValue
+        }
+    }
+    
     init(height: CGFloat, isCopiable: Bool = false) {
         super.init(frame: .zero)
         

--- a/ThreeLinesSummary/Views/PasteView.swift
+++ b/ThreeLinesSummary/Views/PasteView.swift
@@ -19,12 +19,6 @@ class PasteView: PhaseTemplateView {
     
     private func addButtons() {
         stack.addArrangedSubview(translateButton)
-        
-        textField.textPublisher
-            .sink { [unowned self] text in
-                translateButton.decideActivation(with: text)
-            }
-            .store(in: &subscriptions)
     }
     
     required init?(coder: NSCoder) {

--- a/ThreeLinesSummary/Views/SummaryView.swift
+++ b/ThreeLinesSummary/Views/SummaryView.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 class SummaryView: PhaseTemplateView {
-    let goBackButton = UIButton.getSystemButton(title: "처음 단계로", configuration: .filled())
+    let goToStartButton = UIButton.getSystemButton(title: "처음 단계로", configuration: .filled())
     
     init() {
         super.init(title: "요약 완료", instruction: "요약이 완료되었습니다!", textCopiable: true)
@@ -16,7 +16,7 @@ class SummaryView: PhaseTemplateView {
     }
     
     private func addButtons() {
-        stack.addArrangedSubview(goBackButton)
+        stack.addArrangedSubview(goToStartButton)
     }
     
     required init?(coder: NSCoder) {

--- a/ThreeLinesSummary/Views/TranslateView.swift
+++ b/ThreeLinesSummary/Views/TranslateView.swift
@@ -9,7 +9,7 @@ import UIKit
 import Combine
 
 class TranslateView: PhaseTemplateView {
-    let translateButton = UIButton.getSystemButton(title: "예", configuration: .filled())
+    let summarizeButton = UIButton.getSystemButton(title: "예", configuration: .filled())
     let goBackButton = UIButton.getSystemButton(title: "아니오(처음 단계로)", configuration: .tinted())
     private var subscriptions = Set<AnyCancellable>()
     
@@ -27,7 +27,7 @@ class TranslateView: PhaseTemplateView {
         buttonsStack.axis = .horizontal
         buttonsStack.spacing = 10
         
-        [translateButton, goBackButton].forEach { button in
+        [summarizeButton, goBackButton].forEach { button in
             button.translatesAutoresizingMaskIntoConstraints = false
             button.widthAnchor.constraint(equalToConstant: (UIScreen.main.bounds.width - 50) / 2).isActive = true
             buttonsStack.addArrangedSubview(button)
@@ -37,7 +37,7 @@ class TranslateView: PhaseTemplateView {
         
         textField.textPublisher
             .sink { [unowned self] text in
-                translateButton.decideActivation(with: text)
+                summarizeButton.decideActivation(with: text)
             }
             .store(in: &subscriptions)
     }

--- a/ThreeLinesSummary/Views/TranslateView.swift
+++ b/ThreeLinesSummary/Views/TranslateView.swift
@@ -27,7 +27,7 @@ class TranslateView: PhaseTemplateView {
         buttonsStack.axis = .horizontal
         buttonsStack.spacing = 10
         
-        [summarizeButton, goBackButton].forEach { button in
+        [goBackButton, summarizeButton].forEach { button in
             button.translatesAutoresizingMaskIntoConstraints = false
             button.widthAnchor.constraint(equalToConstant: (UIScreen.main.bounds.width - 50) / 2).isActive = true
             buttonsStack.addArrangedSubview(button)

--- a/ThreeLinesSummary/Views/TranslateView.swift
+++ b/ThreeLinesSummary/Views/TranslateView.swift
@@ -34,11 +34,5 @@ class TranslateView: PhaseTemplateView {
         }
         
         stack.addArrangedSubview(buttonsStack)
-        
-        textField.textPublisher
-            .sink { [unowned self] text in
-                summarizeButton.decideActivation(with: text)
-            }
-            .store(in: &subscriptions)
     }
 }


### PR DESCRIPTION
## 설명
* `Phase` 추가
    - 번역 완료, 요약 완료 등의 단계를 나타내는 enum
    - 각 단계에 따른 `navigationTitle` 프로퍼티 제공
* `ViewModel` 추가
    - 여러 `@Published` 프로퍼티를 통해 View 상태 관리 역할
* `ViewController` 수정
    - 여러 View를 프로퍼티로 가짐
    - `ViewModel`의 `@Published` 프로퍼티를 view에 binding하여 상태 변화를 view에 반영

## 파일 경로
ThreeLinesSummary/ViewModels/ViewModel.swift
ThreeLinesSummary/Views/ViewController.swift
