### PR TITLE
버그 수정

### DIFF
--- a/ThreeLinesSummary.xcodeproj/project.pbxproj
+++ b/ThreeLinesSummary.xcodeproj/project.pbxproj
@@ -26,13 +26,13 @@
 		AB2FDAC928BE51990008826F /* Summary_Bad_400_E102.json in Resources */ = {isa = PBXBuildFile; fileRef = AB2FDAC828BE51990008826F /* Summary_Bad_400_E102.json */; };
 		AB2FDACD28BE52170008826F /* Summary_Bad_500.json in Resources */ = {isa = PBXBuildFile; fileRef = AB2FDACC28BE52170008826F /* Summary_Bad_500.json */; };
 		AB2FDACF28BE524E0008826F /* Summary_Bad_Unknown.json in Resources */ = {isa = PBXBuildFile; fileRef = AB2FDACE28BE524E0008826F /* Summary_Bad_Unknown.json */; };
-		AB2FF4E328BF353F0050A03B /* TranslateAPIAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FF4E228BF353F0050A03B /* TranslateAPIAuth.swift */; };
+		AB2FF4E328BF353F0050A03B /* TranslateAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FF4E228BF353F0050A03B /* TranslateAPI.swift */; };
 		AB2FF4E528BF37600050A03B /* NetworkManagerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FF4E428BF37600050A03B /* NetworkManagerIntegrationTests.swift */; };
 		AB2FF4E728BF3C4D0050A03B /* TranslateRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FF4E628BF3C4D0050A03B /* TranslateRequestBody.swift */; };
 		AB2FF4E928BF54710050A03B /* Translate_Good.json in Resources */ = {isa = PBXBuildFile; fileRef = AB2FF4E828BF54710050A03B /* Translate_Good.json */; };
 		AB2FF4F028BF8EFA0050A03B /* SummaryResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FF4EF28BF8EFA0050A03B /* SummaryResponseBody.swift */; };
 		AB2FF4F228BF9A8D0050A03B /* SummaryRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FF4F128BF9A8D0050A03B /* SummaryRequestBody.swift */; };
-		AB2FF4F428BF9C250050A03B /* SummaryAPIAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FF4F328BF9C250050A03B /* SummaryAPIAuth.swift */; };
+		AB2FF4F428BF9C250050A03B /* SummaryAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FF4F328BF9C250050A03B /* SummaryAPI.swift */; };
 		AB3AE7D228BF080300002CF8 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AE7D128BF080300002CF8 /* NetworkError.swift */; };
 		AB3AE7D428BF0A6000002CF8 /* ErrorResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AE7D328BF0A6000002CF8 /* ErrorResponseBody.swift */; };
 		AB3AE7D628BF0C9400002CF8 /* Translate_Bad_NotDecodable.json in Resources */ = {isa = PBXBuildFile; fileRef = AB3AE7D528BF0C9400002CF8 /* Translate_Bad_NotDecodable.json */; };
@@ -84,13 +84,13 @@
 		AB2FDAC828BE51990008826F /* Summary_Bad_400_E102.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Summary_Bad_400_E102.json; sourceTree = "<group>"; };
 		AB2FDACC28BE52170008826F /* Summary_Bad_500.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Summary_Bad_500.json; sourceTree = "<group>"; };
 		AB2FDACE28BE524E0008826F /* Summary_Bad_Unknown.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Summary_Bad_Unknown.json; sourceTree = "<group>"; };
-		AB2FF4E228BF353F0050A03B /* TranslateAPIAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateAPIAuth.swift; sourceTree = "<group>"; };
+		AB2FF4E228BF353F0050A03B /* TranslateAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateAPI.swift; sourceTree = "<group>"; };
 		AB2FF4E428BF37600050A03B /* NetworkManagerIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManagerIntegrationTests.swift; sourceTree = "<group>"; };
 		AB2FF4E628BF3C4D0050A03B /* TranslateRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateRequestBody.swift; sourceTree = "<group>"; };
 		AB2FF4E828BF54710050A03B /* Translate_Good.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Translate_Good.json; sourceTree = "<group>"; };
 		AB2FF4EF28BF8EFA0050A03B /* SummaryResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryResponseBody.swift; sourceTree = "<group>"; };
 		AB2FF4F128BF9A8D0050A03B /* SummaryRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryRequestBody.swift; sourceTree = "<group>"; };
-		AB2FF4F328BF9C250050A03B /* SummaryAPIAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryAPIAuth.swift; sourceTree = "<group>"; };
+		AB2FF4F328BF9C250050A03B /* SummaryAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryAPI.swift; sourceTree = "<group>"; };
 		AB3AE7D128BF080300002CF8 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		AB3AE7D328BF0A6000002CF8 /* ErrorResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorResponseBody.swift; sourceTree = "<group>"; };
 		AB3AE7D528BF0C9400002CF8 /* Translate_Bad_NotDecodable.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Translate_Bad_NotDecodable.json; sourceTree = "<group>"; };
@@ -216,8 +216,8 @@
 		AB2FF4E128BF352E0050A03B /* Secrets */ = {
 			isa = PBXGroup;
 			children = (
-				AB2FF4E228BF353F0050A03B /* TranslateAPIAuth.swift */,
-				AB2FF4F328BF9C250050A03B /* SummaryAPIAuth.swift */,
+				AB2FF4E228BF353F0050A03B /* TranslateAPI.swift */,
+				AB2FF4F328BF9C250050A03B /* SummaryAPI.swift */,
 			);
 			path = Secrets;
 			sourceTree = "<group>";
@@ -440,7 +440,7 @@
 				ABEC710E28BC7F0300488104 /* UIImageView.swift in Sources */,
 				ABEC711028BC81D400488104 /* CustomButton.swift in Sources */,
 				AB2FDA8928BDD9E20008826F /* LoadingView.swift in Sources */,
-				AB2FF4F428BF9C250050A03B /* SummaryAPIAuth.swift in Sources */,
+				AB2FF4F428BF9C250050A03B /* SummaryAPI.swift in Sources */,
 				AB2FF4E728BF3C4D0050A03B /* TranslateRequestBody.swift in Sources */,
 				AB2FDA8328BDC96F0008826F /* TranslateView.swift in Sources */,
 				ABB8B80528B8B0D600B7818F /* AppDelegate.swift in Sources */,
@@ -448,7 +448,7 @@
 				AB2FF4F028BF8EFA0050A03B /* SummaryResponseBody.swift in Sources */,
 				ABB8B80728B8B0D600B7818F /* SceneDelegate.swift in Sources */,
 				ABEC711828BCA9C900488104 /* UIButton.swift in Sources */,
-				AB2FF4E328BF353F0050A03B /* TranslateAPIAuth.swift in Sources */,
+				AB2FF4E328BF353F0050A03B /* TranslateAPI.swift in Sources */,
 				AB2FDA8B28BDE21E0008826F /* ErrorView.swift in Sources */,
 				AB2FDA8528BDD5FA0008826F /* SummaryView.swift in Sources */,
 				AB21AED528C0736200247199 /* ViewModel.swift in Sources */,

--- a/ThreeLinesSummary/Network/NetworkManager.swift
+++ b/ThreeLinesSummary/Network/NetworkManager.swift
@@ -16,7 +16,7 @@ struct NetworkManager {
             throw NetworkError.emptyText
         }
         
-        guard var urlRequest = TranslateAPIAuth.urlRequest else {
+        guard var urlRequest = TranslateAPI.urlRequest else {
             throw NetworkError.unknown
         }
         
@@ -61,7 +61,7 @@ struct NetworkManager {
     }
     
     func summarize(_ text: String) async throws -> String {
-        guard var urlRequest = SummaryAPIAuth.urlRequest else {
+        guard var urlRequest = SummaryAPI.urlRequest else {
             throw NetworkError.unknown
         }
         

--- a/ThreeLinesSummary/ViewController.swift
+++ b/ThreeLinesSummary/ViewController.swift
@@ -21,6 +21,29 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        bindPhaseToViews()
+        bindTextFieldTextToPublished()
+        bindMessageToErrorLoadingView()
+        addTargetsToButtons()
+    }
+
+    @objc private func translateButtonClicked() {
+        viewModel.translate()
+    }
+    
+    @objc private func goBack() {
+        viewModel.goBack()
+    }
+    
+    @objc private func summarize() {
+        viewModel.summarize()
+    }
+    
+    @objc private func goToStart() {
+        viewModel.goToStart()
+    }
+    
+    private func bindPhaseToViews() {
         viewModel.$currentPhase
             .receive(on: DispatchQueue.main)
             .sink { [unowned self] phase in
@@ -40,7 +63,9 @@ class ViewController: UIViewController {
                 self.title = phase.navigationTitle
             }
             .store(in: &subscriptions)
-        
+    }
+    
+    private func bindTextFieldTextToPublished() {
         viewModel.$pastedText
             .receive(on: DispatchQueue.main)
             .assign(to: \.text, on: pasteView.textField)
@@ -56,6 +81,12 @@ class ViewController: UIViewController {
             .assign(to: \.text, on: summaryView.textField)
             .store(in: &subscriptions)
         
+        viewModel.bindPastedText(to: pasteView.textField.textPublisher)
+        viewModel.bindTranslateText(to: translateView.textField.textPublisher)
+        viewModel.bindSummaryText(to: summaryView.textField.textPublisher)
+    }
+    
+    private func bindMessageToErrorLoadingView() {
         viewModel.$loadingMessage
             .receive(on: DispatchQueue.main)
             .assign(to: \.message, on: loadingView)
@@ -65,11 +96,9 @@ class ViewController: UIViewController {
             .receive(on: DispatchQueue.main)
             .assign(to: \.message, on: errorView)
             .store(in: &subscriptions)
-        
-        viewModel.bindPastedText(to: pasteView.textField.textPublisher)
-        viewModel.bindTranslateText(to: translateView.textField.textPublisher)
-        viewModel.bindSummaryText(to: summaryView.textField.textPublisher)
-        
+    }
+    
+    private func addTargetsToButtons() {
         pasteView.translateButton.addTarget(self, action: #selector(translateButtonClicked), for: .touchUpInside)
         translateView.summarizeButton.addTarget(self, action: #selector(summarize), for: .touchUpInside)
         
@@ -80,22 +109,6 @@ class ViewController: UIViewController {
         [errorView.goToStartButton, summaryView.goToStartButton].forEach { [unowned self] button in
             button.addTarget(self, action: #selector(goToStart), for: .touchUpInside)
         }
-    }
-
-    @objc private func translateButtonClicked() {
-        viewModel.translate()
-    }
-    
-    @objc private func goBack() {
-        viewModel.goBack()
-    }
-    
-    @objc private func summarize() {
-        viewModel.summarize()
-    }
-    
-    @objc private func goToStart() {
-        viewModel.goToStart()
     }
 }
 

--- a/ThreeLinesSummary/ViewController.swift
+++ b/ThreeLinesSummary/ViewController.swift
@@ -21,28 +21,18 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        // Binding
         bindPhaseToViews()
         bindTextFieldTextToPublished()
         bindMessageToErrorLoadingView()
+        
+        // Button Actions
         addTargetsToButtons()
     }
+}
 
-    @objc private func translateButtonClicked() {
-        viewModel.translate()
-    }
-    
-    @objc private func goBack() {
-        viewModel.goBack()
-    }
-    
-    @objc private func summarize() {
-        viewModel.summarize()
-    }
-    
-    @objc private func goToStart() {
-        viewModel.goToStart()
-    }
-    
+// MARK: - Binding Methods
+extension ViewController {
     private func bindPhaseToViews() {
         viewModel.$currentPhase
             .receive(on: DispatchQueue.main)
@@ -97,7 +87,10 @@ class ViewController: UIViewController {
             .assign(to: \.message, on: errorView)
             .store(in: &subscriptions)
     }
-    
+}
+
+// MARK: - Button Actions
+extension ViewController {
     private func addTargetsToButtons() {
         pasteView.translateButton.addTarget(self, action: #selector(translateButtonClicked), for: .touchUpInside)
         translateView.summarizeButton.addTarget(self, action: #selector(summarize), for: .touchUpInside)
@@ -110,5 +103,20 @@ class ViewController: UIViewController {
             button.addTarget(self, action: #selector(goToStart), for: .touchUpInside)
         }
     }
+    
+    @objc private func translateButtonClicked() {
+        viewModel.translate()
+    }
+    
+    @objc private func goBack() {
+        viewModel.goBack()
+    }
+    
+    @objc private func summarize() {
+        viewModel.summarize()
+    }
+    
+    @objc private func goToStart() {
+        viewModel.goToStart()
+    }
 }
-

--- a/ThreeLinesSummary/ViewController.swift
+++ b/ThreeLinesSummary/ViewController.swift
@@ -66,6 +66,10 @@ class ViewController: UIViewController {
             .assign(to: \.message, on: errorView)
             .store(in: &subscriptions)
         
+        viewModel.bindPastedText(to: pasteView.textField.textPublisher)
+        viewModel.bindTranslateText(to: translateView.textField.textPublisher)
+        viewModel.bindSummaryText(to: summaryView.textField.textPublisher)
+        
         pasteView.translateButton.addTarget(self, action: #selector(translateButtonClicked), for: .touchUpInside)
         translateView.summarizeButton.addTarget(self, action: #selector(summarize), for: .touchUpInside)
         
@@ -77,7 +81,7 @@ class ViewController: UIViewController {
     }
 
     @objc private func translateButtonClicked() {
-        viewModel.translate(pasteView.textField.text)
+        viewModel.translate()
     }
     
     @objc private func goBack() {
@@ -85,7 +89,7 @@ class ViewController: UIViewController {
     }
     
     @objc private func summarize() {
-        viewModel.summarize(translateView.textField.text)
+        viewModel.summarize()
     }
     
     @objc private func goToStart() {

--- a/ThreeLinesSummary/ViewController.swift
+++ b/ThreeLinesSummary/ViewController.swift
@@ -73,11 +73,13 @@ class ViewController: UIViewController {
         pasteView.translateButton.addTarget(self, action: #selector(translateButtonClicked), for: .touchUpInside)
         translateView.summarizeButton.addTarget(self, action: #selector(summarize), for: .touchUpInside)
         
-        translateView.goBackButton.addTarget(self, action: #selector(goBack), for: .touchUpInside)
-        errorView.goBackButton.addTarget(self, action: #selector(goBack), for: .touchUpInside)
+        [translateView.goBackButton, errorView.goBackButton].forEach { [unowned self] button in
+            button.addTarget(self, action: #selector(goBack), for: .touchUpInside)
+        }
         
-        errorView.goToStartButton.addTarget(self, action: #selector(goToStart), for: .touchUpInside)
-        summaryView.goToStartButton.addTarget(self, action: #selector(goToStart), for: .touchUpInside)
+        [errorView.goToStartButton, summaryView.goToStartButton].forEach { [unowned self] button in
+            button.addTarget(self, action: #selector(goToStart), for: .touchUpInside)
+        }
     }
 
     @objc private func translateButtonClicked() {

--- a/ThreeLinesSummary/Views/Helpers/BorderedTextField.swift
+++ b/ThreeLinesSummary/Views/Helpers/BorderedTextField.swift
@@ -18,7 +18,7 @@ class BorderedTextField: UIView {
     }()
     
     private var textSubject = CurrentValueSubject<String, Never>("")
-    lazy var textPublisher = textSubject.eraseToAnyPublisher()
+    lazy var textPublisher = textSubject.eraseToAnyPublisher().share()
     
     var text: String {
         get {

--- a/ThreeLinesSummary/Views/Helpers/PhaseTemplateView.swift
+++ b/ThreeLinesSummary/Views/Helpers/PhaseTemplateView.swift
@@ -36,6 +36,9 @@ class PhaseTemplateView: UIView {
         instructionLabel.text = instruction
         
         setLayout()
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
+        self.addGestureRecognizer(tapGesture)
     }
     
     private func setLayout() {
@@ -54,5 +57,9 @@ class PhaseTemplateView: UIView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    @objc private func hideKeyboard() {
+        self.endEditing(true)
     }
 }


### PR DESCRIPTION
## 설명
* `@Published` 프로퍼티와 `textfield`의 불일치 버그 수정
    - `ViewModel`에서 `bind~~()` 메서드 정의 및 `ViewController`에서 호출
* 버튼 가려지는 버그 수정
    - `PhaseTemplateView`에서 `textfield` 외의 영역 클릭 시 `hideKeyboard()` 호출
* `ViewController` 코드 리펙터링
    - `viewDidLoad()`의 코드를 여러 extension 및 메서드로 분리
* ~APIAuth -> API로 이름 변경

## 파일 경로
ThreeLinesSummary/ViewModels/ViewModel.swift
ThreeLinesSummary/Secrets/*
ThreeLinesSummary/ViewController.swift
ThreeLinesSummary/Views/Helpers/PhaseTemplateView.swift
ThreeLinesSummary/Views/Helpers/BorderedTextField.swift

